### PR TITLE
Added apiOrigin service property and updated to use supergraph by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,9 @@ Below are all the available properties that can be provided in your app's settin
         "loginStyle": "redirect",
         "clientId": "app*****************",
         "secret": "plys_*******************************************",
-        "accessTokenScope": ["workspace_members:read", "teams:read"]
+        "accessTokenScope": ["workspace_members:read", "teams:read"],
+        "origin": "https://platform.pitchly.com",
+        "apiOrigin": "https://main--pitchly.apollographos.net"
       }
     }
   }
@@ -138,6 +140,8 @@ Below are all the available properties that can be provided in your app's settin
 ```
 
 `accessTokenScope` will cause the access token saved for the user to be downscoped to at most the provided permissions. By default, the access token will possess the maximum permissions allowed to this app. This setting is ideal for situations where you want the app to have elevated permissions, but you don't want the client to have those permissions directly. This list of permissions may be provided as an array or space-delimited string.
+
+`origin` is the origin for OAuth requests. `apiOrigin` is the origin for API requests. These can be customized depending on environment, but above are the defaults.
 
 ### loginWithPitchly options
 

--- a/pitchly_server.js
+++ b/pitchly_server.js
@@ -139,7 +139,7 @@ Meteor.methods({
     (function(accessToken) {
       let response;
       try {
-        const request = fetch(`${config.origin || 'https://platform.pitchly.com'}/graphql`, {
+        const request = fetch(`${config.apiOrigin || 'https://main--pitchly.apollographos.net'}/graphql`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',


### PR DESCRIPTION
Updated to allow pointing to different origins for OAuth requests and API requests via 'origin' and 'apiOrigin' service properties, respectively